### PR TITLE
Added Google Analytics tracking ID and sample poems 

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,19 +65,20 @@
       <!-- Example row of columns -->
       <div class="row">
         <div class="col-md-4">
-          <h2>Heading</h2>
-          <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
-          <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
+          <h2>The Star</h2>
+          <p>A white star born in the evening glow<br>Looked to the round green world below,<br>And saw a pool in a wooded place<br>That held like a jewel her mirrored face.</p>
+          <p><a href="poems/the-star.html">Read more</a>
+            </p>
         </div>
         <div class="col-md-4">
-          <h2>Heading</h2>
-          <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
-          <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
+          <h2>A Drinking Song</h2>
+          <p>Wine comes in at the mouth<br>And love comes in at the eye;<br>That's all we shall know for truth<br></p>
+          <p><a href="poems/a-drinking-song.html">Read more</a></p>
        </div>
         <div class="col-md-4">
-          <h2>Heading</h2>
-          <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
-          <p><a class="btn btn-default" href="#" role="button">View details &raquo;</a></p>
+          <h2>My Typewriter</h2>
+          <p>I have a trim typewriter now,<br>They tell me none is better;<br>It makes a pleasing, rhythmic row,<br>And neat is every letter.<br></p>
+          <p><p><a href="poems/my-typewriter.html">Read more</a></p>
         </div>
       </div>
 
@@ -93,14 +94,14 @@
 
         <script src="js/main.js"></script>
 
-        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
+        <!-- Google Analytics: change UA-113955222-1 to be your site's ID. -->
         <script>
             (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
             function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            ga('create','UA-113955222-1','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/poems/a-drinking-song.html
+++ b/poems/a-drinking-song.html
@@ -1,0 +1,15 @@
+<html>
+        <head><title>A Drinking Song</title></head>
+            <body>
+                <h1>A Drinking Song</h1>
+                    <p class="poemBody">
+                    Wine comes in at the mouth<br>
+                    And love comes in at the eye;<br>
+                    That's all we shall know for truth<br>
+                    Before we grow old and die.<br>
+                    I lift the glass to my mouth,<br>
+                    I look at you, and I sigh.</p>
+
+                    <p class="author">by William Butler Yeats</p>
+            </body>
+</html>

--- a/poems/my-typewriter.html
+++ b/poems/my-typewriter.html
@@ -1,0 +1,35 @@
+<html>
+    <head><title>My Typewriter</title></head>
+        <body>
+            <h1>My Typewriter</h1>
+                <p class="poemBody">
+                I have a trim typewriter now,<br>
+                They tell me none is better;<br>
+                It makes a pleasing, rhythmic row,<br>
+                And neat is every letter.<br>
+                I tick out stories by machine,<br>
+                Dig pars, and gags, and verses keen,<br>
+                And lathe them off in manner slick.<br>
+                It is so easy, and it's quick.<br>
+
+                And yet it falls short, I'm afraid,<br>
+                Of giving satisfaction,<br>
+                This making literature by aid<br>
+                Of scientific traction;<br>
+                For often, I can't fail to see,<br>
+                The dashed thing runs away with me.<br>
+                It bolts, and do whate'er I may<br>
+                I cannot hold the runaway.<br>
+
+                It is not fitted with a brake,<br>
+                And endless are my verses,<br>
+                Nor any yarn I start to make<br>
+                Appropriately terse is.<br>
+                Tis plain that this machine-made screed<br>
+                Is fit but for machines to read;<br>
+                So Wanted (as an iron censor)<br>
+                A good, sound, secondhand condenser!</p>
+
+                <p class="author">by Edward Dyson</p>
+        </body>
+</html>

--- a/poems/the-star.html
+++ b/poems/the-star.html
@@ -1,0 +1,26 @@
+<html>
+    <head><title>The Star</title></head>
+        <body>
+            <h1>The Star</h1>
+                <p class="poemBody">A white star born in the evening glow<br>
+                Looked to the round green world below,<br>
+                And saw a pool in a wooded place<br>
+                That held like a jewel her mirrored face.<br>
+                She said to the pool: "Oh, wondrous deep,<br>
+                I love you, I give you my light to keep.<br>
+                Oh, more profound than the moving sea<br>
+                That never has shown myself to me!<br>
+                Oh, fathomless as the sky is far,<br>
+                Hold forever your tremulous star!"<br>
+                But out of the woods as night grew cool<br>
+                A brown pig came to the little pool;<br>
+                It grunted and splashed and waded in<br>
+                And the deepest place but reached its chin.<br>
+                The water gurgled with tender glee<br>
+                And the mud churned up in it turbidly.<br>
+                The star grew pale and hid her face<br>
+                In a bit of floating cloud like lace.</p>
+
+                <p class="author">by Sara Teasdale</p>
+        </body>
+</html>


### PR DESCRIPTION
This pull request deals with issue #14, which involve adding Google Analytics.

I added 3 poem snippets on the homepage with links to full page versions of them, in order to have links for Google Analytics to track. I also added a real Google Analytics tracking ID to make the analytics code functional.

I've noticed that other team members included sample poems to address other issues. Another team member also added a Google Analytics tracking ID. So some collaboration might be required so that there's not overlap and merge conflicts.
